### PR TITLE
Add support for international Amazon wishlists

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Amazon Wish Lister
 
 This is a little API to retrieve Amazon Wish List data. There is no official API, as Amazon shut it down a couple years ago. The only way around that... screen scraping. It works with both old and new (beta) Amazon Wish List design.
 
+The following Amazon stores have wishlist functionality - Canada, USA, Brasil, Japan, UK, Germany, France, India, Italy.
+
 Amazon Wish Lister uses [phpQuery](http://code.google.com/p/phpquery/) (server-side CSS3 selector driven DOM API based on jQuery) to scrape Amazon's Wish List page and exports to JSON, XML, or PHP Array Object.
 
 * Scrapes the following from your Amazon Wish List:
@@ -32,6 +34,16 @@ You just need to add a few parameters to get your wish list. All of the paramete
 
 The rest (how you style it) is up to you. Happy coding.
 
+### Amazon Country
+`?tld=AMAZON_COUNTRY`  
+`?tld=co.uk`
+
+Defaults to `com`.  
+
+Tested with: `ca`, `com`, `com.br`, `co.jp`, `co.uk`, `de`, `fr`, `in`, `it`.
+
+The following stores currently do not offer wishlists: `com.au`, `com.mx`, `es`, `nl`.
+
 ### Amazon ID
 `?id=YOUR_AMAZON_ID`  
 `?id=37XI10RRD17X2`
@@ -55,7 +67,7 @@ The rest (how you style it) is up to you. Happy coding.
 `?format=array`
 
 ### Example
-`wishlist.php?id=37XI10RRD17X2&reveal=all&sort=priority&format=json`
+`wishlist.php?tld=com&id=37XI10RRD17X2&reveal=all&sort=priority&format=json`
 
 What it returns
 ===============

--- a/src/wishlist.php
+++ b/src/wishlist.php
@@ -18,6 +18,13 @@ require_once('phpquery.php');
 if(isset($_GET['id'])) $amazon_id = $_GET['id'];
 else $amazon_id = '37XI10RRD17X2';
 
+//?tld=AMAZON_COUNTRY
+//Set the regional variant of Amazon to use.  e.g `?tld=co.uk` or `?tld=de` or ?tld=com`. Defaults to `com`
+//Tested with: `ca`, `com`, `com.br`, `co.jp`, `co.uk`, `de`, `fr`, `in`, `it`
+//Currently no wishlists available for: `com.au`, `com.mx`, `es`, `nl` 
+if(isset($_GET['tld'])) $amazon_country = $_GET['tld'];
+else $amazon_country = 'com';
+
 //?reveal=unpurchased
 //checks what to reveal (unpurchased, all, or purchased)... defaults to unpurchased
 if($_GET['reveal'] == 'unpurchased') $reveal = 'reveal=unpurchased';
@@ -35,7 +42,7 @@ elseif($_GET['sort'] == 'price-high') $sort = 'sort=universal-price-desc';
 elseif($_GET['sort'] == 'updated') $sort = 'sort=last-updated';
 else $sort = 'sort=date-added';
 
-$baseurl = 'http://www.amazon.com';
+$baseurl = 'http://www.amazon.' . $amazon_country;
 $content = phpQuery::newDocumentFile("$baseurl/registry/wishlist/$amazon_id?$reveal&$sort&layout=standard");
 $i = 0;
 


### PR DESCRIPTION
This adds a `&tld=` option to allow users to select `co.uk`, `com`, `co.jp` etc.

Defaults to `com` so older scripts don't break.

Fixes #12